### PR TITLE
Don't error if the maildir tree exists

### DIFF
--- a/maildir.go
+++ b/maildir.go
@@ -268,21 +268,19 @@ func Key() (string, error) {
 // function may leave a partially created directory structure.
 func (d Dir) Create() error {
 	err := os.Mkdir(string(d), os.ModeDir|CreateMode)
-	if err != nil {
-		if !os.IsExist(err) {
-			return err
-		}
+	if err != nil && !os.IsExist(err) {
+		return err
 	}
 	err = os.Mkdir(filepath.Join(string(d), "tmp"), os.ModeDir|CreateMode)
-	if err != nil {
+	if err != nil && !os.IsExist(err) {
 		return err
 	}
 	err = os.Mkdir(filepath.Join(string(d), "new"), os.ModeDir|CreateMode)
-	if err != nil {
+	if err != nil && !os.IsExist(err) {
 		return err
 	}
 	err = os.Mkdir(filepath.Join(string(d), "cur"), os.ModeDir|CreateMode)
-	if err != nil {
+	if err != nil && !os.IsExist(err) {
 		return err
 	}
 	return nil

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -64,6 +64,39 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	f, err := os.Open("test_create")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fis, err := f.Readdir(0)
+	subdirs := make(map[string]os.FileInfo)
+	for _, fi := range fis {
+		if !fi.IsDir() {
+			t.Errorf("%s was not a directory", fi.Name())
+			continue
+		}
+		subdirs[fi.Name()] = fi
+	}
+
+	// Verify the directories have been created.
+	if _, ok := subdirs["tmp"]; !ok {
+		t.Error("'tmp' directory was not created")
+	}
+	if _, ok := subdirs["new"]; !ok {
+		t.Error("'new' directory was not created")
+	}
+	if _, ok := subdirs["cur"]; !ok {
+		t.Error("'cur' directory was not created")
+	}
+
+	// Make sure no error is returned if the directories already exist.
+	err = d.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	defer cleanup(t, d)
 }
 


### PR DESCRIPTION
This allows a caller to call `Create()` to ensure the directory has been
created.
- - - - - - - - 
If you like the old behavior, I could add a new method instead of modifying `Create()`.