### PR TITLE
Bugfix: could not use maildir if its path contains globbing chars

### DIFF
--- a/maildir.go
+++ b/maildir.go
@@ -28,6 +28,12 @@ var id int64 = 10000
 // CreateMode holds the permissions used when creating a directory.
 const CreateMode = 0700
 
+var globEsc *strings.Replacer = strings.NewReplacer("[", "\\[",
+	"]", "\\]",
+	"*", "\\*",
+	"?", "\\?",
+	"\\", "\\\\")
+
 // A KeyError occurs when a key matches more or less than one message.
 type KeyError struct {
 	Key string // the (invalid) key
@@ -134,7 +140,7 @@ func (d Dir) Keys() ([]string, error) {
 
 // Filename returns the path to the file corresponding to the key.
 func (d Dir) Filename(key string) (string, error) {
-	matches, err := filepath.Glob(filepath.Join(string(d), "cur", key+"*"))
+	matches, err := filepath.Glob(globEsc.Replace(filepath.Join(string(d), "cur", key)) + "*")
 	if err != nil {
 		return "", err
 	}

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -57,15 +57,23 @@ func makeDelivery(t *testing.T, d Dir, msg string) {
 }
 
 func TestCreate(t *testing.T) {
+	doTestCreate(t, "test_create")
+}
+
+func TestCreateFunnyFolder(t *testing.T) {
+	doTestCreate(t, "test_create_[Funny]")
+}
+
+func doTestCreate(t *testing.T, dirName string) {
 	t.Parallel()
 
-	var d Dir = "test_create"
+	var d Dir = Dir(dirName)
 	err := d.Create()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	f, err := os.Open("test_create")
+	f, err := os.Open(dirName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,9 +109,17 @@ func TestCreate(t *testing.T) {
 }
 
 func TestDelivery(t *testing.T) {
+	doTestDelivery(t, "test_delivery")
+}
+
+func TestDeliveryFunnyFolder(t *testing.T) {
+	doTestDelivery(t, "test_delivery_[Funny]")
+}
+
+func doTestDelivery(t *testing.T, dirName string) {
 	t.Parallel()
 
-	var d Dir = "test_delivery"
+	var d Dir = Dir(dirName)
 	err := d.Create()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes bug with mail dir not able to use mailboxes with patch that contain globbing characters,
a common use case for this is Gmail synchronization with offlineimap, which
 produces folders like [Gmail].Drafts in its default configuration.