### PR TITLE
Fix/filename bugs

### DIFF
--- a/maildir_test.go
+++ b/maildir_test.go
@@ -61,15 +61,23 @@ func makeDelivery(t *testing.T, d Dir, msg string) {
 }
 
 func TestCreate(t *testing.T) {
+	doTestCreate(t, "test_create")
+}
+
+func TestCreateFunnyFolder(t *testing.T) {
+	doTestCreate(t, "test_create_[Funny]")
+}
+
+func doTestCreate(t *testing.T, dirName string) {
 	t.Parallel()
 
-	var d Dir = "test_create"
+	var d Dir = Dir(dirName)
 	err := d.Create()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	f, err := os.Open("test_create")
+	f, err := os.Open(dirName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,9 +113,17 @@ func TestCreate(t *testing.T) {
 }
 
 func TestDelivery(t *testing.T) {
+	doTestDelivery(t, "test_delivery")
+}
+
+func TestDeliveryFunnyFolder(t *testing.T) {
+	doTestDelivery(t, "test_delivery_[Funny]")
+}
+
+func doTestDelivery(t *testing.T, dirName string) {
 	t.Parallel()
 
-	var d Dir = "test_delivery"
+	var d Dir = Dir(dirName)
 	err := d.Create()
 	if err != nil {
 		t.Fatal(err)

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -54,6 +54,10 @@ func makeDelivery(t *testing.T, d Dir, msg string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = d.Filename(del.key)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestCreate(t *testing.T) {


### PR DESCRIPTION
Fixes two bugs:

1. Maildir was not able to use mailboxes with path that contains globbing characters,
a common use case for this is Gmail synchronization with offlineimap, which
produces folders like [Gmail].Drafts in its default configuration.
2. Filename did not look up keys for newly delivered messages in the "new" subdir

As you suggested I've replaced Glob by scanning directory looking for matching file names. 