### PR TITLE
Feature/accelerate key lookup

### DIFF
--- a/maildir_test.go
+++ b/maildir_test.go
@@ -61,15 +61,23 @@ func makeDelivery(t *testing.T, d Dir, msg string) {
 }
 
 func TestCreate(t *testing.T) {
+	doTestCreate(t, "test_create")
+}
+
+func TestCreateFunnyFolder(t *testing.T) {
+	doTestCreate(t, "test_create_[Funny]")
+}
+
+func doTestCreate(t *testing.T, dirName string) {
 	t.Parallel()
 
-	var d Dir = "test_create"
+	var d Dir = Dir(dirName)
 	err := d.Create()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	f, err := os.Open("test_create")
+	f, err := os.Open(dirName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,9 +113,17 @@ func TestCreate(t *testing.T) {
 }
 
 func TestDelivery(t *testing.T) {
+	doTestDelivery(t, "test_delivery")
+}
+
+func TestDeliveryFunnyFolder(t *testing.T) {
+	doTestDelivery(t, "test_delivery_[Funny]")
+}
+
+func doTestDelivery(t *testing.T, dirName string) {
 	t.Parallel()
 
-	var d Dir = "test_delivery"
+	var d Dir = Dir(dirName)
 	err := d.Create()
 	if err != nil {
 		t.Fatal(err)

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -54,6 +54,10 @@ func makeDelivery(t *testing.T, d Dir, msg string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = d.Filename(del.key)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestCreate(t *testing.T) {


### PR DESCRIPTION
Accelerate key lookup by trying to open files with legal :info suffixes
(according to the maildir spec) before doing full directory scan.  It
greately increases key lookup speed when mail folder is big.  It
introduces some subtle change in error handling: previously the lookup
would fail on duplicate keys, now we don't: there is no quick way to
detect all duplicates without doing full directory scan.