### PR TITLE
Fix: Key lookup may fail if message path contains glob characters []

### DIFF
--- a/maildir.go
+++ b/maildir.go
@@ -134,14 +134,30 @@ func (d Dir) Keys() ([]string, error) {
 
 // Filename returns the path to the file corresponding to the key.
 func (d Dir) Filename(key string) (string, error) {
-	matches, err := filepath.Glob(filepath.Join(string(d), "cur", key+"*"))
+	n := 0
+	var matchedFile string
+	dirPath := filepath.Join(string(d), "cur")
+	f, err := os.Open(dirPath)
 	if err != nil {
 		return "", err
 	}
-	if n := len(matches); n != 1 {
+	defer f.Close()
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		return "", err
+	}
+	for _, name := range names {
+		if strings.HasPrefix(name, key) {
+			if n == 0 {
+				matchedFile = filepath.Join(dirPath, name)
+			}
+			n++
+		}
+	}
+	if n != 1 {
 		return "", &KeyError{key, n}
 	}
-	return matches[0], nil
+	return matchedFile, nil
 }
 
 // Header returns the corresponding mail header to a key.

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -101,9 +101,17 @@ func TestCreate(t *testing.T) {
 }
 
 func TestDelivery(t *testing.T) {
+	doTestDelivery(t, "test_delivery")
+}
+
+func TestDeliveryFunnyFolder(t *testing.T) {
+	doTestDelivery(t, "test_delivery_[Funny]")
+}
+
+func doTestDelivery(t *testing.T, dirName string) {
 	t.Parallel()
 
-	var d Dir = "test_delivery"
+	var d Dir = Dir(dirName)
 	err := d.Create()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
As you suggested, I replaced use of Glob() by scanning the "cur" directory and doing
prefix lookup on directory entries and removed the handling of the unseen messages 
from the patch.