### PR TITLE
Feature/accelerate message lookup

### DIFF
--- a/maildir.go
+++ b/maildir.go
@@ -132,10 +132,94 @@ func (d Dir) Keys() ([]string, error) {
 	return keys, nil
 }
 
+func fileExists(filename string) bool {
+	finfo, err := os.Stat(filename)
+	return err == nil && finfo.Mode().IsRegular()
+}
+
+var suffices []string = []string{
+	"",
+	"S",
+	"D",
+	"F",
+	"P",
+	"R",
+	"T",
+	"DF",
+	"DP",
+	"DR",
+	"DS",
+	"DT",
+	"FP",
+	"FR",
+	"FS",
+	"FT",
+	"PR",
+	"PS",
+	"PT",
+	"RS",
+	"RT",
+	"ST",
+	"DFP",
+	"DFR",
+	"DFS",
+	"DFT",
+	"DPR",
+	"DPS",
+	"DPT",
+	"DRS",
+	"DRT",
+	"DST",
+	"FPR",
+	"FPS",
+	"FPT",
+	"FRS",
+	"FRT",
+	"FST",
+	"PRS",
+	"PRT",
+	"PST",
+	"RST",
+	"DFPR",
+	"DFPS",
+	"DFPT",
+	"DFRS",
+	"DFRT",
+	"DFST",
+	"DPRS",
+	"DPRT",
+	"DPST",
+	"DRST",
+	"FPRS",
+	"FPRT",
+	"FPST",
+	"FRST",
+	"PRST",
+	"DFPRS",
+	"DFPRT",
+	"DFPST",
+	"DFRST",
+	"DPRST",
+	"FPRST",
+	"DFPRST"}
+
+// quick check for existance of legal (per DJB) file names for a key
+func (d Dir) quickFilename(key string) string {
+	// "cur" files must have :info suffix
+	filePrefix := filepath.Join(string(d), "cur", key+string(Separator)+"2,")
+	for _, suffix := range suffices {
+		if filename := filePrefix + suffix; fileExists(filename) {
+			return filename
+		}
+	}
+	return ""
+}
+
 // Filename returns the path to the file corresponding to the key.
 func (d Dir) Filename(key string) (string, error) {
-	n := 0
-	var matchedFile string
+	if matchedFile := d.quickFilename(key); matchedFile != "" {
+		return matchedFile, nil
+	}
 	dirPath := filepath.Join(string(d), "cur")
 	f, err := os.Open(dirPath)
 	if err != nil {
@@ -148,16 +232,10 @@ func (d Dir) Filename(key string) (string, error) {
 	}
 	for _, name := range names {
 		if strings.HasPrefix(name, key) {
-			if n == 0 {
-				matchedFile = filepath.Join(dirPath, name)
-			}
-			n++
+			return filepath.Join(dirPath, name), nil
 		}
 	}
-	if n != 1 {
-		return "", &KeyError{key, n}
-	}
-	return matchedFile, nil
+	return "", &KeyError{key, 0}
 }
 
 // Header returns the corresponding mail header to a key.

--- a/maildir.go
+++ b/maildir.go
@@ -134,14 +134,30 @@ func (d Dir) Keys() ([]string, error) {
 
 // Filename returns the path to the file corresponding to the key.
 func (d Dir) Filename(key string) (string, error) {
-	matches, err := filepath.Glob(filepath.Join(string(d), "cur", key+"*"))
+	n := 0
+	var matchedFile string
+	dirPath := filepath.Join(string(d), "cur")
+	f, err := os.Open(dirPath)
 	if err != nil {
 		return "", err
 	}
-	if n := len(matches); n != 1 {
+	defer f.Close()
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		return "", err
+	}
+	for _, name := range names {
+		if strings.HasPrefix(name, key) {
+			if n == 0 {
+				matchedFile = filepath.Join(dirPath, name)
+			}
+			n++
+		}
+	}
+	if n != 1 {
 		return "", &KeyError{key, n}
 	}
-	return matches[0], nil
+	return matchedFile, nil
 }
 
 // Header returns the corresponding mail header to a key.

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -101,9 +101,17 @@ func TestCreate(t *testing.T) {
 }
 
 func TestDelivery(t *testing.T) {
+	doTestDelivery(t, "test_delivery")
+}
+
+func TestDeliveryFunnyFolder(t *testing.T) {
+	doTestDelivery(t, "test_delivery_[Funny]")
+}
+
+func doTestDelivery(t *testing.T, dirName string) {
 	t.Parallel()
 
-	var d Dir = "test_delivery"
+	var d Dir = Dir(dirName)
 	err := d.Create()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Accelerate filename by trying to open files with legal :info suffixes
(according to the maildir spec) before trying a full directory scan.
It greatly increases key lookup speed when the mail folder is big.  It
introduces some subtle change in error handling: previously, the
lookup would fail on duplicate keys, now we don't: there is no quick
way to detect all duplicates without doing a full directory scan.